### PR TITLE
[watchman] fix windows build by requiring newer python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
+# 3.19+ has improved python discovery
+cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
 
 set(CMAKE_MODULE_PATH
   # For in-fbsource builds on mac
@@ -403,7 +404,7 @@ if(NOT WIN32)
   endif()
 endif()
 
-find_package(Python3 COMPONENTS Interpreter Development)
+find_package(Python3 3.10...3.99 COMPONENTS Interpreter Development)
 
 if(NOT Python3_Interpreter_FOUND)
   message(STATUS "python not found, using default python")

--- a/build/fbcode_builder/getdeps/cargo.py
+++ b/build/fbcode_builder/getdeps/cargo.py
@@ -13,7 +13,7 @@ import sys
 import typing
 
 from .builder import BuilderBase
-from .copytree import simple_copytree
+from .copytree import rmtree_more, simple_copytree
 
 if typing.TYPE_CHECKING:
     from .buildopts import BuildOptions
@@ -79,7 +79,7 @@ class CargoBuilder(BuilderBase):
             if os.path.islink(dst):
                 os.remove(dst)
             else:
-                shutil.rmtree(dst)
+                rmtree_more(dst)
         simple_copytree(src, dst)
 
     def recreate_linked_dir(self, src, dst) -> None:

--- a/build/fbcode_builder/manifests/python-setuptools-69
+++ b/build/fbcode_builder/manifests/python-setuptools-69
@@ -1,0 +1,18 @@
+[manifest]
+name = python-setuptools-69
+
+[download]
+url = https://files.pythonhosted.org/packages/c0/7a/3da654f49c95d0cc6e9549a855b5818e66a917e852ec608e77550c8dc08b/setuptools-69.1.1-py3-none-any.whl
+sha256 = 02fa291a0471b3a18b2b2481ed902af520c69e8ae0919c13da936542754b4c56
+
+[build]
+builder = python-wheel
+
+[rpms]
+python3-setuptools
+
+[homebrew]
+python-setuptools
+
+[debs]
+python3-setuptools

--- a/build/fbcode_builder/manifests/watchman
+++ b/build/fbcode_builder/manifests/watchman
@@ -19,7 +19,7 @@ fbthrift
 folly
 pcre2
 googletest
-python-setuptools
+python-setuptools-69
 
 [dependencies.fbsource=on]
 rust

--- a/watchman/integration/lib/WatchmanInstance.py
+++ b/watchman/integration/lib/WatchmanInstance.py
@@ -233,16 +233,15 @@ class _Instance:
             raise val
 
     def _waitForSuspend(self, suspended, timeout: float) -> bool:
-        if os.name == "nt":
-            # There's no 'ps' equivalent we can use
-            return True
-
-        # Check the information in the 'ps' output
+        # Check the information in the 'ps' or 'powershell' output
         deadline = time.time() + timeout
         state = "s" if sys.platform.startswith("sunos") else "state"
+        cmd = ["ps", "-o", state, "-p", str(self.pid)]
+        if os.name == "nt":
+            cmd = [self._susresBinary(), "status", str(self.pid)]
         while time.time() < deadline:
             out, err = subprocess.Popen(
-                ["ps", "-o", state, "-p", str(self.pid)],
+                cmd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             ).communicate()

--- a/watchman/integration/lib/WatchmanTestCase.py
+++ b/watchman/integration/lib/WatchmanTestCase.py
@@ -95,13 +95,13 @@ class WatchmanTestCase(TempDirPerTestMixin, unittest.TestCase):
 
     def __init__(self, methodName: str = "run") -> None:
         super(WatchmanTestCase, self).__init__(methodName)
+        # ASAN-enabled builds can be slower enough that we hit timeouts
+        # with the default of 1 second. Needs to be before setDefaultConfiguration
+        self.socketTimeout = 80.0
         # pyre-fixme[16]: `WatchmanTestCase` has no attribute `setDefaultConfiguration`.
         self.setDefaultConfiguration()
         self.maxDiff = None
         self.attempt = 0
-        # ASAN-enabled builds can be slower enough that we hit timeouts
-        # with the default of 1 second
-        self.socketTimeout = 80.0
 
     def requiresPersistentSession(self) -> bool:
         return False

--- a/watchman/python/pywatchman/__init__.py
+++ b/watchman/python/pywatchman/__init__.py
@@ -846,7 +846,7 @@ class client:
         self,
         sockpath=None,
         tcpAddress=None,
-        timeout=1.0,
+        timeout=None,
         transport=None,
         sendEncoding=None,
         recvEncoding=None,
@@ -857,6 +857,11 @@ class client:
         valueErrors=False,
         binpath=None,
     ):
+        if timeout is None:
+            if os.name == "nt":
+                timeout = 2
+            else:
+                timeout = 1
         if sockpath is not None and not isinstance(sockpath, SockPath):
             sockpath = SockPath(sockpath=sockpath, tcp_address=tcpAddress)
         self.sockpath = sockpath

--- a/watchman/winbuild/susres.cpp
+++ b/watchman/winbuild/susres.cpp
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <windows.h>
+#include <tlhelp32.h>
 
 // Super simple utility to suspend or resume all threads in a target process.
 // We use this in place of `kill -STOP` and `kill -CONT`
@@ -64,32 +65,125 @@ int apply(DWORD pid, BOOL suspend) {
   return res == 0 ? 0 : 1;
 }
 
+int status(DWORD pid) {
+  HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
+  if (snapshot == INVALID_HANDLE_VALUE) {
+    fmt::print(
+        "Failed to CreateToolhelp32Snapshot: {}\n",
+        win32_strerror(GetLastError()));
+    return 1;
+  }
+
+  THREADENTRY32 entry;
+  entry.dwSize = sizeof(entry);
+
+  BOOL haveThread = Thread32First(snapshot, &entry);
+  bool foundThread = false;
+  bool allSuspended = true;
+
+  while (haveThread) {
+    if (entry.th32OwnerProcessID == pid) {
+      foundThread = true;
+      HANDLE thread =
+          OpenThread(THREAD_SUSPEND_RESUME, FALSE, entry.th32ThreadID);
+      if (!thread) {
+        fmt::print(
+            "Failed to OpenThread({}): {}\n",
+            entry.th32ThreadID,
+            win32_strerror(GetLastError()));
+        CloseHandle(snapshot);
+        return 1;
+      }
+
+      DWORD previousCount = SuspendThread(thread);
+      if (previousCount == static_cast<DWORD>(-1)) {
+        fmt::print(
+            "SuspendThread({}) failed: {}\n",
+            entry.th32ThreadID,
+            win32_strerror(GetLastError()));
+        CloseHandle(thread);
+        CloseHandle(snapshot);
+        return 1;
+      }
+
+      DWORD resumeCount = ResumeThread(thread);
+      if (resumeCount == static_cast<DWORD>(-1)) {
+        fmt::print(
+            "ResumeThread({}) failed: {}\n",
+            entry.th32ThreadID,
+            win32_strerror(GetLastError()));
+        CloseHandle(thread);
+        CloseHandle(snapshot);
+        return 1;
+      }
+
+      if (previousCount == 0) {
+        allSuspended = false;
+        CloseHandle(thread);
+        break;
+      }
+
+      CloseHandle(thread);
+    }
+
+    haveThread = Thread32Next(snapshot, &entry);
+  }
+
+  CloseHandle(snapshot);
+
+  if (!foundThread) {
+    fmt::print("No threads found for pid {}\n", pid);
+    return 1;
+  }
+
+  fmt::print("{}\n", allSuspended ? "T" : "R");
+  return 0;
+}
+
 void usage() {
   fmt::print(
       "Usage: susres suspend [pid]\n"
-      "       susres resume  [pid\n");
+      "       susres resume  [pid]\n"
+      "       susres status  [pid]\n");
   exit(1);
 }
 
+enum class Command {
+  Suspend,
+  Resume,
+  Status,
+};
+
 int main(int argc, char** argv) {
   DWORD pid;
-  BOOL suspend;
+  Command cmd;
 
   if (argc != 3) {
     usage();
   }
 
   if (!strcmp(argv[1], "suspend")) {
-    suspend = TRUE;
+    cmd = Command::Suspend;
   } else if (!strcmp(argv[1], "resume")) {
-    suspend = FALSE;
+    cmd = Command::Resume;
+  } else if (!strcmp(argv[1], "status")) {
+    cmd = Command::Status;
   } else {
     usage();
   }
 
   pid = _atoi64(argv[2]);
 
-  return apply(pid, suspend);
+  switch (cmd) {
+    case Command::Suspend:
+      return apply(pid, TRUE);
+    case Command::Resume:
+      return apply(pid, FALSE);
+    case Command::Status:
+      return status(pid);
+  }
+
+  return 1;
 }
 
 /* vim:ts=2:sw=2:et:


### PR DESCRIPTION
Summary:

Github CI was finding an old python install and erroring with  `AttributeError: module 'setuptools.dist' has no attribute 'check_test_suite'` https://github.com/facebook/watchman/actions/runs/19440507973/job/55622405533#step:131:1188

Fix by updating the python3 cmake discovery to find 3.11+

Also fix the cargo.py remove behaviour to use rmtree_more.  This fixes repeat local builds while debugging. After the first buildI was getting `PermissionError: [WinError 5] Access is denied: 'Z:\\build\\fbthrift\\source\\.git\\objects\\pack\\pack-250eb41d409d8c0f512fdb239d0225fa35d50c3d.idx'`

Test Plan:

python build/fbcode_builder/getdeps.py build --src-dir=. watchman --scratch-path='C:\s' --cmake-target=pywatchman